### PR TITLE
Actualiza el soporte de markdown a la extensión MyST-Parser

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -36,7 +36,7 @@ extensions = [
     'sphinxcontrib.images',
     'sphinx.ext.viewcode',
     'sphinx.ext.autodoc',
-    'recommonmark'
+     'myst_parser'
 ]
 
 

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -2,5 +2,4 @@ sphinx==2.4.4
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-images==0.9.1
 sphinx-intl==0.9.11
-recommonmark==0.6.0
-sphinx-markdown-tables==0.0.15
+myst_parser


### PR DESCRIPTION
Actualiza el soporte de markdown a la extensión [MyST-Parser](https://myst-parser.readthedocs.io/en/latest/) porque la extensión  [recommonmark](https://github.com/readthedocs/recommonmark) está obsoleta. 